### PR TITLE
Fix rustls-tls feature to avoid compiling native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["discord", "discord-api", "webhook", "discord-webhook", "network"]
 categories = ["network-programming", "api-bindings"]
 
 [features]
-default = ["reqwest/json", "reqwest/multipart"]
-rustls-tls = ["reqwest/json", "reqwest/multipart", "reqwest/rustls-tls"]
+default = []
+rustls-tls = ["reqwest/rustls-tls", "reqwest/json", "reqwest/multipart"]
 
 [dependencies]
 thiserror = "1.0"
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 
-reqwest = "0.12"
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart"] }
 url = "2.5"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }


### PR DESCRIPTION
The rustls-tls feature was not properly preventing native-tls from being compiled. This commit adjusts the Cargo.toml feature flags to explicitly exclude native-tls when rustls-tls is enabled.